### PR TITLE
Adjustments for OpenSSL download and cast

### DIFF
--- a/BreadWallet.xcodeproj/project.pbxproj
+++ b/BreadWallet.xcodeproj/project.pbxproj
@@ -3231,7 +3231,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "VERSION=1.0.1i\nARCHIVE=openssl-$VERSION.tar.gz\nSHA1=74eed314fa2c93006df8d26cd9fc630a101abd76\n\ncd $SRCROOT\nrm -rf $SRCROOT/openssl\nln -s openssl-$VERSION openssl\n\n([ -f $SRCROOT/$ARCHIVE ] && openssl sha1 $SRCROOT/$ARCHIVE | grep $SHA1) || \\\n(rm -rf $SRCROOT/openssl-* && curl -sSO http://www.openssl.org/source/$ARCHIVE && \\\nopenssl sha1 $SRCROOT/$ARCHIVE | grep $SHA1)\n\n[ -f $SRCROOT/openssl/ssl/tls_srp.c ] || tar -xvzf $ARCHIVE";
+			shellScript = "VERSION=1.0.1i\nARCHIVE=openssl-$VERSION.tar.gz\nSHA1=74eed314fa2c93006df8d26cd9fc630a101abd76\n\ncd $SRCROOT\nrm -rf $SRCROOT/openssl\nln -s openssl-$VERSION openssl\n\n([ -f $SRCROOT/$ARCHIVE ] && openssl sha1 $SRCROOT/$ARCHIVE | grep $SHA1) || \\\n(rm -rf $SRCROOT/openssl-* && curl -sSO https://www.openssl.org/source/$ARCHIVE && \\\nopenssl sha1 $SRCROOT/$ARCHIVE | grep $SHA1)\n\n[ -f $SRCROOT/openssl/ssl/tls_srp.c ] || tar -xvzf $ARCHIVE";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/BreadWallet/BRPeerManager.m
+++ b/BreadWallet/BRPeerManager.m
@@ -906,8 +906,8 @@ static const char *dns_seeds[] = {
 - (void)sortPeers
 {
     [_peers sortUsingComparator:^NSComparisonResult(id obj1, id obj2) {
-        if ([obj1 timestamp] > [obj2 timestamp]) return NSOrderedAscending;
-        if ([obj1 timestamp] < [obj2 timestamp]) return NSOrderedDescending;
+        if ([(BRPeer*) obj1 timestamp] > [(BRPeer*) obj2 timestamp]) return NSOrderedAscending;
+        if ([(BRPeer*) obj1 timestamp] < [(BRPeer*) obj2 timestamp]) return NSOrderedDescending;
         return NSOrderedSame;
     }];
 }
@@ -1097,7 +1097,7 @@ static const char *dns_seeds[] = {
     NSTimeInterval t = [NSDate timeIntervalSinceReferenceDate] - 3*60*60;
 
     // remove peers more than 3 hours old, or until there are only 1000 left
-    while (self.peers.count > 1000 && [self.peers.lastObject timestamp] < t) {
+    while (self.peers.count > 1000 && [(BRPeer*)self.peers.lastObject timestamp] < t) {
         [self.peers removeObject:self.peers.lastObject];
     }
 


### PR DESCRIPTION
1. The OpenSSL download requires HTTPS and redirects to this page. Therefore curl downloads a 302 HTML page but not the archive.
2. compiler error: timestamp needs to be casted to BRPeer*
